### PR TITLE
Update mprLib.c

### DIFF
--- a/src/mpr/mprLib.c
+++ b/src/mpr/mprLib.c
@@ -7597,7 +7597,7 @@ PUBLIC char *mprGetRandomString(ssize size)
     bytes = mprAlloc(size / 2);
     ascii = mprAlloc(size + 1);
 
-    if (mprGetRandomBytes(bytes, sizeof(bytes), 0) < 0) {
+    if (mprGetRandomBytes(bytes, size / 2, 0) < 0) {
         mprLog("critical mpr", 0, "Failed to get random bytes");
         now = mprGetTime();
         pid = (int) getpid();


### PR DESCRIPTION
Generally this API is called to generate XSRF Token with size=32.
bytes is allocated for 16 chars.
Now call to mprGetRandomBytes is made to fill those 16 chars with random numbers between 0 to 255. However, size being passed is just sizeof(bytes) which returns 4 (size of a pointer) and not 16 which is length of string. So only first 4 chars are randomnly generated. Remaining characters are whichver left from the mprAlloc call.