### PR TITLE
FIX: Restore upload file size limit check per route

### DIFF
--- a/src/mpr/mprLib.c
+++ b/src/mpr/mprLib.c
@@ -25355,12 +25355,15 @@ PUBLIC MprThread *mprGetCurrentThread()
     ts = MPR->threadService;
     if (ts && ts->threads) {
         id = mprGetCurrentOsThread();
+        lock(ts->threads);
         for (i = 0; i < ts->threads->length; i++) {
             tp = mprGetItem(ts->threads, i);
             if (tp->osThread == id) {
+                unlock(ts->threads);
                 return tp;
             }
         }
+        unlock(ts->threads);
     }
     return 0;
 }


### PR DESCRIPTION
Since v8.2.0 upload file size limit defined per route by
"LimitRequestBody" stopped working.

The previous existing code in processParsed() is restored
and do the limit check after routing is applied.