### PR TITLE
FIX: Don't continue with outgoingFileService if file pointer gone

### DIFF
--- a/paks/http/dist/httpLib.c
+++ b/paks/http/dist/httpLib.c
@@ -7831,6 +7831,11 @@ static void outgoingFileService(HttpQueue *q)
     rx = stream->rx;
     tx = stream->tx;
 
+    if (!tx->file) {
+        /* File download has been aborted early and file has been closed */
+        return;
+    }
+
     /*
         The queue will contain a dummy entity packet which holds the position from which to read in the file.
         If the downstream queue is full, the data packet will be put onto the queue ahead of the entity packet.

--- a/src/http/httpLib.c
+++ b/src/http/httpLib.c
@@ -7831,6 +7831,11 @@ static void outgoingFileService(HttpQueue *q)
     rx = stream->rx;
     tx = stream->tx;
 
+    if (!tx->file) {
+        /* File download has been aborted early and file has been closed */
+        return;
+    }
+
     /*
         The queue will contain a dummy entity packet which holds the position from which to read in the file.
         If the downstream queue is full, the data packet will be put onto the queue ahead of the entity packet.


### PR DESCRIPTION
If the transfer is aborted early, the close handler is called, which
closes the file and NULLs the file pointer. outgoingFileService is called
at least once after this and because the filepointer is NULL this causes a crash
in mprSeekFile in readFileData

Signed-off-by: Luuk Paulussen <luuk.paulussen@alliedtelesis.co.nz>